### PR TITLE
Add configurable org-mode file paths with wildcard and tilde support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An MCP (Model Context Protocol) server for working with Org Mode files and workf
 - 📡 Standard stdio transport for MCP communication
 - 🎯 Ready for integration with Claude Desktop
 - 🛠️ Development-friendly with hot reloading
+- 📁 Configurable org-mode file paths with wildcard support
 
 ## Quick Start
 
@@ -29,6 +30,25 @@ An MCP (Model Context Protocol) server for working with Org Mode files and workf
    ```bash
    npm run build
    ```
+
+4. Create a `config.json` file in the project root:
+   ```json
+   {
+     "orgFiles": [
+       "/path/to/your/org/files/*.org",
+       "/path/to/specific-file.org",
+       "~/Documents/notes/**/*.org"
+     ]
+   }
+   ```
+
+   The `orgFiles` array supports:
+   - Absolute file paths: `/Users/username/notes/work.org`
+   - Wildcard patterns: `/Users/username/notes/*.org`
+   - Recursive patterns: `/Users/username/notes/**/*.org`
+   - Prefix matching: `/Users/username/notes/life*.org`
+
+   See the [Configuration](#configuration) section for more details.
 
 ### Running the Server
 
@@ -55,12 +75,78 @@ Then send a JSON-RPC message like:
 {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
 ```
 
+## Configuration
+
+The server requires a `config.json` file in the project root directory to specify which org-mode files to process.
+
+### Configuration File Format
+
+```json
+{
+  "orgFiles": [
+    "/absolute/path/to/file.org",
+    "/path/to/directory/*.org",
+    "/path/with/wildcard/life*.org"
+  ]
+}
+```
+
+### Supported Path Patterns
+
+- **Absolute paths**: `/Users/username/notes/work.org`
+- **Wildcard patterns**:
+  - `*.org` - All .org files in a directory
+  - `**/*.org` - All .org files recursively
+  - `life*.org` - Files starting with "life"
+- **Multiple patterns**: List multiple paths and patterns in the array
+
+### Validation
+
+When the server starts, it will:
+- Validate the configuration file structure
+- Expand all glob patterns to find matching files
+- Report errors if:
+  - The config file is missing or invalid JSON
+  - The `orgFiles` array is empty or missing
+  - No files match the specified patterns
+- Display warnings if:
+  - Individual patterns match no files
+  - Pattern expansion encounters errors
+
+### Example Configurations
+
+**Simple configuration:**
+```json
+{
+  "orgFiles": ["/Users/martin/notes/work.org"]
+}
+```
+
+**Multiple files with wildcards:**
+```json
+{
+  "orgFiles": [
+    "/Users/martin/Dropbox/orgmode/work.org",
+    "/Users/martin/Dropbox/orgmode/life*.org",
+    "/tmp/scratch.org"
+  ]
+}
+```
+
+**Recursive pattern:**
+```json
+{
+  "orgFiles": ["/Users/martin/Documents/**/*.org"]
+}
+```
+
 ## Project Structure
 
 ```
 src/
 ├── index.ts          # Main entry point
-├── server.ts         # Server setup and configuration  
+├── server.ts         # Server setup and configuration
+├── config.ts         # Configuration loader and validator
 ├── handlers/         # Request handlers
 │   ├── tools.ts      # Tool request handlers
 │   └── resources.ts  # Resource request handlers
@@ -76,7 +162,9 @@ src/
 - `npm run start` - Run the compiled server
 - `npm run dev` - Run with TypeScript and hot reloading
 - `npm run clean` - Clean build artifacts
-- `npm test` - Run tests (placeholder)
+- `npm test` - Run tests
+- `npm run test:watch` - Run tests in watch mode
+- `npm run test:coverage` - Run tests with coverage report
 
 ## Integration with Claude Desktop
 
@@ -86,13 +174,26 @@ See [docs/claude-integration.md](./docs/claude-integration.md) for detailed inst
 
 See [docs/development.md](./docs/development.md) for guidelines on extending the server with new tools and resources.
 
-## Environment Variables
+### Testing
 
-Copy `.env.example` to `.env` and modify as needed:
+The project includes comprehensive tests for all modules:
 
 ```bash
-cp .env.example .env
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Generate coverage report
+npm run test:coverage
 ```
+
+Tests are located in the `tests/` directory and cover:
+- Configuration loading and validation (tests/config.test.ts)
+- Server initialization (tests/server.test.ts)
+- Request handlers (tests/handlers.test.ts)
+- Tool implementations (tests/tools.test.ts)
 
 ## License
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,7 @@
+{
+    "orgFiles": [
+        "/path/to/orgmode/files/work*.org",
+        "/path/to/orgmode/files/life*.org",
+        "~/tmp/scratch.org"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.1",
+        "fast-glob": "^3.3.3",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -18,7 +19,7 @@
       "devDependencies": {
         "@jest/globals": "^30.2.0",
         "@types/jest": "^30.0.0",
-        "@types/node": "^24.9.1",
+        "@types/node": "^24.10.1",
         "jest": "^30.2.0",
         "ts-jest": "^29.4.5",
         "tsx": "^4.20.6",
@@ -1470,6 +1471,41 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1616,9 +1652,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
-      "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2173,7 +2209,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2969,11 +3004,36 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2989,7 +3049,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3209,6 +3268,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3402,6 +3473,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3422,11 +3502,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4353,11 +4444,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -4738,7 +4837,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4861,6 +4959,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4951,6 +5069,16 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -4965,6 +5093,29 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -5487,7 +5638,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@jest/globals": "^30.2.0",
     "@types/jest": "^30.0.0",
-    "@types/node": "^24.9.1",
+    "@types/node": "^24.10.1",
     "jest": "^30.2.0",
     "ts-jest": "^29.4.5",
     "tsx": "^4.20.6",
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.20.1",
+    "fast-glob": "^3.3.3",
     "zod": "^3.25.76"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'fs';
+import { resolve, isAbsolute, dirname } from 'path';
+import { homedir } from 'os';
+import fg from 'fast-glob';
+import { z } from 'zod';
+
+/**
+ * Schema for the configuration file
+ */
+const ConfigSchema = z.object({
+  orgFiles: z.array(z.string()).min(1, 'At least one org file path must be specified'),
+});
+
+export type Config = z.infer<typeof ConfigSchema>;
+
+/**
+ * Validation result for configuration
+ */
+export interface ConfigValidationResult {
+  isValid: boolean;
+  config?: Config;
+  expandedPaths?: string[];
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Load and validate the configuration file from the project root
+ *
+ * @param configPath Path to the config.json file (defaults to ./config.json)
+ * @returns Validation result with expanded file paths
+ */
+export function loadConfig(configPath: string = './config.json'): ConfigValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Resolve the config path
+  const resolvedPath = resolve(configPath);
+
+  // Try to read the config file
+  let rawConfig: unknown;
+  try {
+    const fileContent = readFileSync(resolvedPath, 'utf-8');
+    rawConfig = JSON.parse(fileContent);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      errors.push(`Configuration file not found at: ${resolvedPath}`);
+    } else if (error instanceof SyntaxError) {
+      errors.push(`Invalid JSON in configuration file: ${error.message}`);
+    } else {
+      errors.push(`Error reading configuration file: ${(error as Error).message}`);
+    }
+    return { isValid: false, errors, warnings };
+  }
+
+  // Validate the structure
+  const parseResult = ConfigSchema.safeParse(rawConfig);
+  if (!parseResult.success) {
+    errors.push('Configuration validation failed:');
+    parseResult.error.errors.forEach(err => {
+      errors.push(`  - ${err.path.join('.')}: ${err.message}`);
+    });
+    return { isValid: false, errors, warnings };
+  }
+
+  const config = parseResult.data;
+
+  // Expand glob patterns and collect all matching files
+  const expandedPaths: string[] = [];
+  const configDir = dirname(resolvedPath);
+
+  for (const pattern of config.orgFiles) {
+    try {
+      // Expand tilde (~) to home directory
+      let expandedPattern = pattern.startsWith('~/')
+        ? pattern.replace(/^~/, homedir())
+        : pattern;
+
+      // If it's an absolute path, use it as-is; otherwise resolve relative to config file
+      const searchPattern = isAbsolute(expandedPattern) ? expandedPattern : resolve(configDir, expandedPattern);
+
+      // Use fast-glob to expand the pattern
+      const matches = fg.sync(searchPattern, {
+        absolute: true,
+        onlyFiles: true,
+        dot: false,
+      });
+
+      if (matches.length === 0) {
+        warnings.push(`No files found matching pattern: ${pattern}`);
+      } else {
+        expandedPaths.push(...matches);
+      }
+    } catch (error) {
+      warnings.push(`Error expanding pattern "${pattern}": ${(error as Error).message}`);
+    }
+  }
+
+  // Check if any files were found
+  if (expandedPaths.length === 0) {
+    errors.push('No org files found matching the specified patterns');
+    return { isValid: false, config, errors, warnings };
+  }
+
+  // Remove duplicates (in case patterns overlap)
+  const uniquePaths = Array.from(new Set(expandedPaths));
+
+  return {
+    isValid: true,
+    config,
+    expandedPaths: uniquePaths,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Validate configuration and log results
+ * Throws an error if configuration is invalid
+ *
+ * @param configPath Path to the config.json file
+ * @returns Array of expanded file paths
+ */
+export function validateAndLoadConfig(configPath?: string): string[] {
+  const result = loadConfig(configPath);
+
+  // Log warnings
+  if (result.warnings.length > 0) {
+    console.warn('Configuration warnings:');
+    result.warnings.forEach(warning => console.warn(`  ⚠️  ${warning}`));
+  }
+
+  // Handle errors
+  if (!result.isValid || result.errors.length > 0) {
+    console.error('Configuration errors:');
+    result.errors.forEach(error => console.error(`  ❌ ${error}`));
+    throw new Error('Invalid configuration. Please check config.json');
+  }
+
+  // Log success
+  console.log(`✅ Configuration loaded successfully`);
+  console.log(`   Found ${result.expandedPaths!.length} org file(s):`);
+  result.expandedPaths!.forEach(path => console.log(`   - ${path}`));
+
+  return result.expandedPaths!;
+}

--- a/src/handlers/resources.ts
+++ b/src/handlers/resources.ts
@@ -6,7 +6,7 @@ import {
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
 
-export function setupResourceHandlers(server: Server): void {
+export function setupResourceHandlers(server: Server, orgFilePaths: string[]): void {
   // List available resources
   server.setRequestHandler(ListResourcesRequestSchema, async () => {
     return {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 // Import tool implementations
 import { createExampleTool } from '../tools/example.js';
 
-export function setupToolHandlers(server: Server): void {
+export function setupToolHandlers(server: Server, orgFilePaths: string[]): void {
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,19 @@
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createServer } from './server.js';
+import { validateAndLoadConfig } from './config.js';
 
 async function main() {
-  const server = createServer();
+  // Load and validate configuration
+  let orgFilePaths: string[];
+  try {
+    orgFilePaths = validateAndLoadConfig();
+  } catch (error) {
+    console.error('Failed to load configuration:', (error as Error).message);
+    process.exit(1);
+  }
+
+  const server = createServer(orgFilePaths);
   const transport = new StdioServerTransport();
   await server.connect(transport);
   

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,7 @@ import {
 import { setupToolHandlers } from './handlers/tools.js';
 import { setupResourceHandlers } from './handlers/resources.js';
 
-export function createServer(): Server {
+export function createServer(orgFilePaths: string[]): Server {
   const server = new Server(
     {
       name: 'orgmode-mcp',
@@ -26,8 +26,8 @@ export function createServer(): Server {
   );
 
   // Set up handlers
-  setupToolHandlers(server);
-  setupResourceHandlers(server);
+  setupToolHandlers(server, orgFilePaths);
+  setupResourceHandlers(server, orgFilePaths);
 
   // Error handling
   server.onerror = (error) => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { loadConfig, validateAndLoadConfig } from '../src/config';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+
+describe('Config Module', () => {
+  const testDir = join(__dirname, 'test-fixtures');
+  const configPath = join(testDir, 'config.json');
+
+  beforeEach(() => {
+    // Create test directory
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    try {
+      rmSync(testDir, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe('loadConfig', () => {
+    it('should load a valid config file', () => {
+      // Create actual test files
+      const testFile1 = join(testDir, 'test.org');
+      const testFile2 = join(testDir, 'another.org');
+      writeFileSync(testFile1, '* Test 1');
+      writeFileSync(testFile2, '* Test 2');
+
+      const config = {
+        orgFiles: [testFile1, testFile2],
+      };
+      writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(true);
+      expect(result.config).toEqual(config);
+      expect(result.errors).toHaveLength(0);
+      expect(result.expandedPaths).toHaveLength(2);
+    });
+
+    it('should return error when config file does not exist', () => {
+      const result = loadConfig(join(testDir, 'nonexistent.json'));
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('not found');
+    });
+
+    it('should return error for invalid JSON', () => {
+      writeFileSync(configPath, '{ invalid json }');
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('Invalid JSON');
+    });
+
+    it('should return error when orgFiles is missing', () => {
+      const config = {};
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should return error when orgFiles is empty', () => {
+      const config = { orgFiles: [] };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.some(e => e.toLowerCase().includes('at least one') || e.includes('must be specified'))).toBe(true);
+    });
+
+    it('should return error when orgFiles is not an array', () => {
+      const config = { orgFiles: 'not-an-array' };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should expand glob patterns', () => {
+      // Create test org files
+      const testOrgDir = join(testDir, 'org');
+      mkdirSync(testOrgDir, { recursive: true });
+      writeFileSync(join(testOrgDir, 'file1.org'), '* Heading 1');
+      writeFileSync(join(testOrgDir, 'file2.org'), '* Heading 2');
+      writeFileSync(join(testOrgDir, 'life-todo.org'), '* TODO Task');
+
+      const config = {
+        orgFiles: [
+          join(testOrgDir, '*.org'),
+        ],
+      };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(true);
+      expect(result.expandedPaths).toBeDefined();
+      expect(result.expandedPaths!.length).toBe(3);
+    });
+
+    it('should support absolute paths', () => {
+      // Create a test org file
+      const testFile = join(testDir, 'absolute-test.org');
+      writeFileSync(testFile, '* Test');
+
+      const config = {
+        orgFiles: [testFile],
+      };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(true);
+      expect(result.expandedPaths).toContain(testFile);
+    });
+
+    it('should support wildcard patterns with prefix', () => {
+      // Create test org files
+      const testOrgDir = join(testDir, 'org');
+      mkdirSync(testOrgDir, { recursive: true });
+      writeFileSync(join(testOrgDir, 'life-todo.org'), '* TODO');
+      writeFileSync(join(testOrgDir, 'life-notes.org'), '* Notes');
+      writeFileSync(join(testOrgDir, 'work.org'), '* Work');
+
+      const config = {
+        orgFiles: [
+          join(testOrgDir, 'life*.org'),
+        ],
+      };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(true);
+      expect(result.expandedPaths).toBeDefined();
+      expect(result.expandedPaths!.length).toBe(2);
+      expect(result.expandedPaths!.every(p => p.includes('life'))).toBe(true);
+    });
+
+    it('should warn when pattern matches no files', () => {
+      const config = {
+        orgFiles: [
+          join(testDir, 'nonexistent*.org'),
+          join(testDir, 'alsonothere.org'),
+        ],
+      };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(false);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.errors.some(e => e.includes('No org files found'))).toBe(true);
+    });
+
+    it('should remove duplicate paths when patterns overlap', () => {
+      // Create test org file
+      const testFile = join(testDir, 'test.org');
+      writeFileSync(testFile, '* Test');
+
+      const config = {
+        orgFiles: [
+          testFile,
+          testFile, // Same file twice
+          join(testDir, '*.org'), // Pattern that includes the same file
+        ],
+      };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const result = loadConfig(configPath);
+
+      expect(result.isValid).toBe(true);
+      expect(result.expandedPaths).toBeDefined();
+      // Should have only one instance of the file
+      const testFilePaths = result.expandedPaths!.filter(p => p === testFile);
+      expect(testFilePaths.length).toBe(1);
+    });
+
+    it('should expand tilde (~) to home directory', () => {
+      // Create test org file in a temp location
+      const testFile = join(testDir, 'home-test.org');
+      writeFileSync(testFile, '* Test');
+
+      // Use a pattern with tilde that we'll expand to the test directory
+      // We'll use the testDir path but replace the beginning with ~
+      // For testing purposes, just verify tilde expansion logic works
+      const homeDir = require('os').homedir();
+
+      // Create a file in home tmp if it exists
+      const homeTmpDir = join(homeDir, 'tmp');
+      let actualTestFile: string;
+      try {
+        mkdirSync(homeTmpDir, { recursive: true });
+        actualTestFile = join(homeTmpDir, 'tilde-test.org');
+        writeFileSync(actualTestFile, '* Tilde Test');
+
+        const config = {
+          orgFiles: ['~/tmp/tilde-test.org'],
+        };
+        writeFileSync(configPath, JSON.stringify(config));
+
+        const result = loadConfig(configPath);
+
+        expect(result.isValid).toBe(true);
+        expect(result.expandedPaths).toBeDefined();
+        expect(result.expandedPaths!.length).toBe(1);
+        expect(result.expandedPaths![0]).toBe(actualTestFile);
+
+        // Cleanup
+        rmSync(actualTestFile, { force: true });
+      } catch (error) {
+        // Skip test if we can't create files in home directory
+        console.log('Skipping tilde expansion test - cannot create test file in home directory');
+      }
+    });
+  });
+
+  describe('validateAndLoadConfig', () => {
+    it('should return expanded paths for valid config', () => {
+      // Create test org file
+      const testFile = join(testDir, 'test.org');
+      writeFileSync(testFile, '* Test');
+
+      const config = {
+        orgFiles: [testFile],
+      };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      const paths = validateAndLoadConfig(configPath);
+
+      expect(paths).toBeDefined();
+      expect(paths).toContain(testFile);
+    });
+
+    it('should throw error for invalid config', () => {
+      const config = { orgFiles: [] };
+      writeFileSync(configPath, JSON.stringify(config));
+
+      expect(() => {
+        validateAndLoadConfig(configPath);
+      }).toThrow('Invalid configuration');
+    });
+
+    it('should throw error when config file does not exist', () => {
+      expect(() => {
+        validateAndLoadConfig(join(testDir, 'nonexistent.json'));
+      }).toThrow();
+    });
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -4,9 +4,10 @@ import { createServer } from '../src/server';
 
 describe('MCP Server', () => {
   let server: Server;
+  const mockOrgFiles = ['/tmp/test.org'];
 
   beforeEach(() => {
-    server = createServer();
+    server = createServer(mockOrgFiles);
   });
 
   it('should create a server instance', () => {


### PR DESCRIPTION
Implements issue #3 - support for user-configurable org-mode file locations through a simple config.json file.

Features:
- JSON-based configuration with type-safe validation using Zod
- Glob pattern support (*.org, **/*.org, life*.org)
- Tilde (~) expansion for home directory paths
- Comprehensive validation with clear error messages
- Warning system for patterns matching no files
- Fast-glob integration for efficient file discovery
- 23 passing tests including config validation and path expansion

Changes:
- Add src/config.ts: Configuration loader with validation
- Add config.json: Example configuration file
- Update src/index.ts: Load config on startup
- Update src/server.ts: Accept org file paths parameter
- Update handlers to receive file paths
- Add tests/config.test.ts: Comprehensive test coverage
- Update README.md: Documentation for configuration
- Add fast-glob dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)