### PR TITLE
[example-config] Move config to example file pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ jspm_packages/
 # Generated MCP configuration (user-specific)
 mcp.json
 
+# User-specific configuration
+config.json
+
 # parcel-bundler cache
 .cache
 .parcel-cache

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ An MCP (Model Context Protocol) server for working with Org Mode files and workf
    npm run build
    ```
 
-4. Create a `config.json` file in the project root:
+4. Configure your org-mode files:
+   ```bash
+   cp config-example.json config.json
+   ```
+
+   Then edit `config.json` to specify the paths to your org-mode files:
    ```json
    {
      "orgFiles": [
@@ -47,6 +52,7 @@ An MCP (Model Context Protocol) server for working with Org Mode files and workf
    - Wildcard patterns: `/Users/username/notes/*.org`
    - Recursive patterns: `/Users/username/notes/**/*.org`
    - Prefix matching: `/Users/username/notes/life*.org`
+   - Tilde expansion: `~/Documents/notes/*.org`
 
    See the [Configuration](#configuration) section for more details.
 
@@ -79,6 +85,11 @@ Then send a JSON-RPC message like:
 
 The server requires a `config.json` file in the project root directory to specify which org-mode files to process.
 
+**Setup**: Copy `config-example.json` to `config.json` and update the paths to point to your org-mode files:
+```bash
+cp config-example.json config.json
+```
+
 ### Configuration File Format
 
 ```json
@@ -86,7 +97,8 @@ The server requires a `config.json` file in the project root directory to specif
   "orgFiles": [
     "/absolute/path/to/file.org",
     "/path/to/directory/*.org",
-    "/path/with/wildcard/life*.org"
+    "/path/with/wildcard/life*.org",
+    "~/Documents/notes/*.org"
   ]
 }
 ```

--- a/config-example.json
+++ b/config-example.json
@@ -1,0 +1,7 @@
+{
+    "orgFiles": [
+        "/path/to/orgmode/files/work*.org",
+        "/path/to/orgmode/files/life*.org",
+        "~/tmp/scratch.org"
+  ]
+}

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-  "orgFiles": [
-    "/Users/mremy/devhome/github/orgmode-mcp/.conductor/olympia/sample-org-files/*.org"
-  ]
-}


### PR DESCRIPTION
## Summary
- Moved `config.json` to `config-example.json` with original placeholder paths from PR #4
- Added `config.json` to `.gitignore` to prevent committing user-specific configurations
- Updated README.md with clear instructions to copy and customize the example config

## Rationale
The previous approach had a working `config.json` committed to the repository, which could lead to users accidentally committing their personal org-mode file paths. This change follows the common pattern of using example configuration files.

## Changes
- Created `config-example.json` with placeholder paths (work*.org, life*.org, ~/tmp/scratch.org)
- Removed `config.json` from git tracking
- Added `config.json` to `.gitignore` under "User-specific configuration" section
- Updated Quick Start section in README to include copy step
- Enhanced Configuration section with setup instructions
- Added tilde expansion examples in documentation

## Testing
Users should now:
1. Copy `config-example.json` to `config.json`
2. Edit `config.json` with their own org-mode file paths
3. Run the server without concerns about committing personal paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)