### PR TITLE
[fix-stdout-logging] Fix MCP protocol errors from stdout logging

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -124,10 +124,10 @@ export function loadConfig(configPath: string = './config.json'): ConfigValidati
 export function validateAndLoadConfig(configPath?: string): string[] {
   const result = loadConfig(configPath);
 
-  // Log warnings
+  // Log warnings to stderr (stdout is reserved for MCP protocol)
   if (result.warnings.length > 0) {
-    console.warn('Configuration warnings:');
-    result.warnings.forEach(warning => console.warn(`  ⚠️  ${warning}`));
+    console.error('Configuration warnings:');
+    result.warnings.forEach(warning => console.error(`  ⚠️  ${warning}`));
   }
 
   // Handle errors
@@ -137,10 +137,10 @@ export function validateAndLoadConfig(configPath?: string): string[] {
     throw new Error('Invalid configuration. Please check config.json');
   }
 
-  // Log success
-  console.log(`✅ Configuration loaded successfully`);
-  console.log(`   Found ${result.expandedPaths!.length} org file(s):`);
-  result.expandedPaths!.forEach(path => console.log(`   - ${path}`));
+  // Log success to stderr (stdout is reserved for MCP protocol)
+  console.error(`✅ Configuration loaded successfully`);
+  console.error(`   Found ${result.expandedPaths!.length} org file(s):`);
+  result.expandedPaths!.forEach(path => console.error(`   - ${path}`));
 
   return result.expandedPaths!;
 }


### PR DESCRIPTION
## Issue
https://startupgrind.atlassian.net/browse/fix-stdout-logging

## Summary
Fixes MCP JSON-RPC protocol errors caused by diagnostic messages being written to stdout instead of stderr.

## Problem
The server was logging configuration messages like "✅ Configuration loaded successfully" and file listings to stdout using `console.log` and `console.warn`. Since MCP uses stdio transport for JSON-RPC communication, any non-JSON output on stdout causes parsing errors in MCP clients.

This resulted in errors like:
- `Unexpected token '✅', "✅ Configur"... is not valid JSON`
- `Unexpected token 'F', "   Found 6 or"... is not valid JSON`
- `No number after minus sign in JSON`

## Solution
Changed all diagnostic logging in `validateAndLoadConfig()` to use `console.error`, which writes to stderr. This keeps stdout clean for the MCP protocol while maintaining visibility of configuration status and warnings.

## Changes
- Modified `src/config.ts` to use `console.error` for all diagnostic output
- Added comments explaining that stdout is reserved for MCP protocol
- No functional changes to configuration loading or validation logic

## Testing
- [x] Build succeeds with no TypeScript errors
- [x] All logging now goes to stderr
- [x] No `console.log`, `console.info`, or direct stdout writes remain in codebase
- [x] Configuration with glob patterns works correctly
- [x] README documentation remains accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)