### PR TITLE
[add-server-description] Add server description to MCP server

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ export function createServer(orgFilePaths: string[]): Server {
     {
       name: 'orgmode-mcp',
       version: '1.0.0',
+      description: 'Provides access to Org Mode files for task management, note-taking, and structured data. Use this server to read, search, and analyze org-mode tasks, schedules, and hierarchical outlines.',
     },
     {
       capabilities: {


### PR DESCRIPTION
## Issue
https://startupgrind.atlassian.net/browse/add-server-description

## Summary
Added a description field to the MCP server info object so applications can easily understand what this server does and when they should use it.

## Testing
Build and runtime verification confirm the server initializes correctly with the description field.